### PR TITLE
Use Redis#exists? to fix deprecation warning

### DIFF
--- a/lib/remote_lock/adapters/redis.rb
+++ b/lib/remote_lock/adapters/redis.rb
@@ -18,7 +18,7 @@ module RemoteLock::Adapters
 
       # check if another client has the key.
       # it's important to still run a transaction to clear the watch.
-      have_competition = @connection.exists(key)
+      have_competition = @connection.respond_to?(:exists?) ? @connection.exists?(key) : @connection.exists(key)
 
       !! @connection.multi do
         break if have_competition


### PR DESCRIPTION
When using redis-rb 4+:

```
Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead.
```